### PR TITLE
migrate to mapster

### DIFF
--- a/src/templates/api/ApplicationName.Api.Application.Test/Services/ExampleServiceTest.cs
+++ b/src/templates/api/ApplicationName.Api.Application.Test/Services/ExampleServiceTest.cs
@@ -9,8 +9,9 @@ using ApplicationName.Shared.Aggregates;
 using ApplicationName.Shared.Commands;
 using AutoFixture;
 using AutoFixture.AutoFakeItEasy;
-using AutoMapper;
 using FakeItEasy;
+using Mapster;
+using MapsterMapper;
 using MassTransit;
 using Microsoft.Extensions.Caching.Distributed;
 using NUnit.Framework;
@@ -50,8 +51,9 @@ public class ExampleServiceTest
         _sendEndpoint = _fixture.Freeze<ISendEndpoint>();
         A.CallTo(() => _bus.GetSendEndpoint(A<Uri>._)).Returns(_sendEndpoint);
 
-        var mappingConfig = new MapperConfiguration(cfg => { cfg.AddProfile(new MappingProfile()); });
-        _mapper = mappingConfig.CreateMapper();
+        var mapperConfig = TypeAdapterConfig.GlobalSettings;
+        mapperConfig.Scan(typeof(MappingProfile).Assembly);
+        _mapper = new Mapper(mapperConfig);
         _fixture.Register(() => _mapper);
 
         _subjectUnderTest = _fixture.Create<ExampleService>();
@@ -282,13 +284,12 @@ public class ExampleServiceTest
         var ci = typeof(ExampleDocument).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes);
         var instance = (ExampleDocument)ci!.Invoke(null);
 
-        var mapper = new MapperConfiguration(configure =>
-        {
-            configure.ShouldMapProperty = i => i.PropertyType.IsPublic || i.PropertyType.IsNotPublic;
-            configure.CreateMap<IAggregate, DocumentBase>();
-            configure.CreateMap<IExample, ExampleDocument>();
-            configure.CreateMap<IExampleValueObject, ExampleValueObject>();
-        }).CreateMapper();
+        var config = TypeAdapterConfig.GlobalSettings;
+        config.NewConfig<IAggregate, DocumentBase>();
+        config.NewConfig<IExample, ExampleDocument>();
+        config.NewConfig<IExampleValueObject, ExampleValueObject>()
+            .MapToConstructor(typeof(ExampleValueObject).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes)!);
+        var mapper = new Mapper(config);
 
         mapper.Map(A.Dummy<IAggregate>(), instance);
 

--- a/src/templates/api/ApplicationName.Api.Application/ApplicationName.Api.Application.csproj
+++ b/src/templates/api/ApplicationName.Api.Application/ApplicationName.Api.Application.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="ArgDefender" Version="1.1.0" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="MassTransit" Version="8.3.6" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.2" />
     <PackageReference Include="protobuf-net" Version="3.2.46" />

--- a/src/templates/api/ApplicationName.Api.Application/Services/ExampleService.cs
+++ b/src/templates/api/ApplicationName.Api.Application/Services/ExampleService.cs
@@ -4,7 +4,7 @@ using ApplicationName.Api.Contracts;
 using ApplicationName.Api.Contracts.Dtos;
 using ApplicationName.Shared.Commands;
 using ArgDefender;
-using AutoMapper;
+using MapsterMapper;
 using MassTransit;
 using Microsoft.Extensions.Caching.Distributed;
 

--- a/src/templates/api/ApplicationName.Api/ApplicationName.Api.csproj
+++ b/src/templates/api/ApplicationName.Api/ApplicationName.Api.csproj
@@ -9,8 +9,9 @@
   </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Mapster" Version="7.4.0" />
+    <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.1.0" />
     <PackageReference Include="MassTransit" Version="8.3.6" />
     <PackageReference Include="MassTransit.MongoDb" Version="8.3.6" />

--- a/src/templates/api/ApplicationName.Api/MappingProfile.cs
+++ b/src/templates/api/ApplicationName.Api/MappingProfile.cs
@@ -3,23 +3,23 @@ using ApplicationName.Api.Application.Documents;
 using ApplicationName.Api.Contracts.Dtos;
 using ApplicationName.Shared.Commands;
 using ApplicationName.Shared.Events;
-using AutoMapper;
+using Mapster;
 
 namespace ApplicationName.Api;
 
 [ExcludeFromCodeCoverage]
-public class MappingProfile : Profile
+public class MappingProfile : IRegister
 {
-    public MappingProfile()
+    public void Register(TypeAdapterConfig config)
     {
         // API -> Application
-        CreateMap<CreateExampleDto, CreateExampleCommand>();
-        CreateMap<UpdateExampleDto, UpdateExampleCommand>();
-        CreateMap<ExampleValueObjectDto, ExampleValueObjectEventData>();
+        config.NewConfig<CreateExampleDto, CreateExampleCommand>();
+        config.NewConfig<UpdateExampleDto, UpdateExampleCommand>();
+        config.NewConfig<ExampleValueObjectDto, ExampleValueObjectEventData>();
 
         // Application -> API
-        CreateMap<ExampleDocument, ExampleCollectionDto>();
-        CreateMap<ExampleDocument, ExampleDetailsDto>();
-        CreateMap<ExampleValueObject, ExampleValueObjectDto>();
+        config.NewConfig<ExampleDocument, ExampleCollectionDto>();
+        config.NewConfig<ExampleDocument, ExampleDetailsDto>();
+        config.NewConfig<ExampleValueObject, ExampleValueObjectDto>();
     }
 }

--- a/src/templates/api/ApplicationName.Api/Program.cs
+++ b/src/templates/api/ApplicationName.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Reflection;
 using ApplicationName.Api.Application.Repositories;
 using ApplicationName.Api.Application.Services;
 using ApplicationName.Api.Consumers;
@@ -9,6 +10,7 @@ using ApplicationName.Api.Validators;
 using ApplicationName.Shared.Commands;
 using FluentValidation;
 using FluentValidation.AspNetCore;
+using Mapster;
 using MassTransit;
 using MassTransit.Logging;
 using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
@@ -56,8 +58,9 @@ public static class Program
         // SignalR
         services.AddSignalR();
 
-        // AutoMapper
-        services.AddAutoMapper(i => i.AddProfile<MappingProfile>());
+        // Mapster
+        services.AddMapster();
+        TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
 
         // MassTransit + RabbitMQ
         services.AddMassTransit(i =>

--- a/src/templates/worker/ApplicationName.Worker.Application.Test/ApplicationName.Worker.Application.Test.csproj
+++ b/src/templates/worker/ApplicationName.Worker.Application.Test/ApplicationName.Worker.Application.Test.csproj
@@ -10,7 +10,6 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
-		<PackageReference Include="AutoMapper" Version="13.0.1" />
 		<PackageReference Include="coverlet.msbuild" Version="6.0.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/templates/worker/ApplicationName.Worker.Test/Consumers/CommandHandlerTest.cs
+++ b/src/templates/worker/ApplicationName.Worker.Test/Consumers/CommandHandlerTest.cs
@@ -7,8 +7,9 @@ using ApplicationName.Worker.Consumers;
 using ApplicationName.Worker.Contracts.Commands;
 using AutoFixture;
 using AutoFixture.AutoFakeItEasy;
-using AutoMapper;
 using FakeItEasy;
+using Mapster;
+using MapsterMapper;
 using MassTransit;
 using NUnit.Framework;
 using Shouldly;
@@ -30,7 +31,9 @@ public class CommandHandlerTest
     {
         _fixture = new Fixture().Customize(new AutoFakeItEasyCustomization());
 
-        _mapper = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>()).CreateMapper();
+        var mapperConfig = TypeAdapterConfig.GlobalSettings;
+        mapperConfig.Scan(typeof(MappingProfile).Assembly);
+        _mapper = new Mapper(mapperConfig);
         _fixture.Register(() => _mapper);
 
         _applicationService = _fixture.Freeze<IApplicationService>();

--- a/src/templates/worker/ApplicationName.Worker.Test/Consumers/ExternalEventHandlerTest.cs
+++ b/src/templates/worker/ApplicationName.Worker.Test/Consumers/ExternalEventHandlerTest.cs
@@ -2,8 +2,9 @@ using ApplicationName.Worker.Consumers;
 using ApplicationName.Worker.Contracts.Commands;
 using AutoFixture;
 using AutoFixture.AutoFakeItEasy;
-using AutoMapper;
 using FakeItEasy;
+using Mapster;
+using MapsterMapper;
 using MassTransit;
 using NUnit.Framework;
 using Other.Worker.Contracts.Commands;
@@ -28,7 +29,9 @@ public class ExternalEventHandlerTest
     {
         _fixture = new Fixture().Customize(new AutoFakeItEasyCustomization());
 
-        _mapper = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>()).CreateMapper();
+        var mapperConfig = TypeAdapterConfig.GlobalSettings;
+        mapperConfig.Scan(typeof(MappingProfile).Assembly);
+        _mapper = new Mapper(mapperConfig);
         _fixture.Register(() => _mapper);
 
         EndpointConvention.Map<SetExampleRemoteCodeCommand>(new Uri("queue:test"));

--- a/src/templates/worker/ApplicationName.Worker/ApplicationName.Worker.csproj
+++ b/src/templates/worker/ApplicationName.Worker/ApplicationName.Worker.csproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="Mapster" Version="7.4.0" />
+    <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="MassTransit" Version="8.3.6" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />

--- a/src/templates/worker/ApplicationName.Worker/Consumers/CommandHandler.cs
+++ b/src/templates/worker/ApplicationName.Worker/Consumers/CommandHandler.cs
@@ -2,7 +2,7 @@ using ApplicationName.Shared.Commands;
 using ApplicationName.Shared.Events;
 using ApplicationName.Worker.Application.Services;
 using ApplicationName.Worker.Contracts.Commands;
-using AutoMapper;
+using MapsterMapper;
 using MassTransit;
 
 namespace ApplicationName.Worker.Consumers;

--- a/src/templates/worker/ApplicationName.Worker/Consumers/ExternalEventHandler.cs
+++ b/src/templates/worker/ApplicationName.Worker/Consumers/ExternalEventHandler.cs
@@ -1,5 +1,5 @@
 using ApplicationName.Worker.Contracts.Commands;
-using AutoMapper;
+using MapsterMapper;
 using MassTransit;
 using Other.Worker.Contracts.Commands;
 

--- a/src/templates/worker/ApplicationName.Worker/MappingProfile.cs
+++ b/src/templates/worker/ApplicationName.Worker/MappingProfile.cs
@@ -2,23 +2,20 @@ using System.Diagnostics.CodeAnalysis;
 using ApplicationName.Shared.Events;
 using ApplicationName.Worker.Application.DomainEvents;
 using ApplicationName.Worker.Contracts.Commands;
-using AutoMapper;
+using Mapster;
 using Other.Worker.Contracts.Commands;
 
 namespace ApplicationName.Worker;
 
 [ExcludeFromCodeCoverage]
-public class MappingProfile : Profile
+public class MappingProfile : IRegister
 {
-    public MappingProfile()
+    public void Register(TypeAdapterConfig config)
     {
-        CreateMap<ExternalEvent, SetExampleRemoteCodeCommand>()
-            .ForMember(dst => dst.RemoteCode, src =>
-                src.MapFrom(i => i.Code));
-
-        CreateMap<ExampleCreated, ExampleCreatedEvent>();
-        CreateMap<ExampleUpdated, ExampleUpdatedEvent>();
-        CreateMap<ExampleValueObjectEvent, ExampleValueObjectEventData>();
-        CreateMap<ExampleRemoteCodeSet, ExampleRemoteCodeSetEvent>();
+        config.NewConfig<ExternalEvent, SetExampleRemoteCodeCommand>().Map(dest => dest.RemoteCode, src => src.Code);
+        config.NewConfig<ExampleCreated, ExampleCreatedEvent>();
+        config.NewConfig<ExampleUpdated, ExampleUpdatedEvent>();
+        config.NewConfig<ExampleValueObjectEvent, ExampleValueObjectEventData>();
+        config.NewConfig<ExampleRemoteCodeSet, ExampleRemoteCodeSetEvent>();
     }
 }

--- a/src/templates/worker/ApplicationName.Worker/Program.cs
+++ b/src/templates/worker/ApplicationName.Worker/Program.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Reflection;
 using ApplicationName.Worker.Application;
 using ApplicationName.Worker.Application.Services;
 using ApplicationName.Worker.Consumers;
 using ApplicationName.Worker.Contracts.Commands;
 using ApplicationName.Worker.Infrastructure;
+using Mapster;
 using MassTransit;
 using MassTransit.Logging;
 using MongoDB.Bson;
@@ -47,8 +49,9 @@ public static class Program
         clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber());
         services.AddSingleton<IMongoClient>(_ => new MongoClient(clientSettings));
 
-        // AutoMapper
-        services.AddAutoMapper(i => i.AddProfile<MappingProfile>());
+        // Mapster
+        services.AddMapster();
+        TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
 
         // MassTransit
         services.AddMassTransit(i =>


### PR DESCRIPTION
This pull request involves a significant refactor of the codebase to replace the usage of AutoMapper with Mapster. The changes span across multiple files, primarily focusing on updating the mapping configurations, dependency injections, and package references.

### Migration from AutoMapper to Mapster:

* **Package References:**
  * Replaced `AutoMapper` package with `Mapster` and `Mapster.DependencyInjection` in `ApplicationName.Api.Application.csproj` and `ApplicationName.Worker.csproj`. [[1]](diffhunk://#diff-41711e81865fc1be9c8cd6f88a861bc4deb7a6289d81e2297e5a488acaa74ca0L11-R11) [[2]](diffhunk://#diff-09e8b830dd4f1f5587d2f9aa974b8ec0c633fa21b7679550472da178ce0d028bL12-R14) [[3]](diffhunk://#diff-9e77ff72223865a5101d2acf30d647afeba7bb2c55b62462df388969fc79e70cL12-R13)

* **Mapping Configuration:**
  * Updated `MappingProfile` classes to implement `IRegister` interface and use `TypeAdapterConfig` for defining mappings instead of `Profile` and `CreateMap` methods. [[1]](diffhunk://#diff-141d845f9f30e0c906e2575fdb0deff9388a744f6ca820c6de575f61ae5be8b1L6-R23) [[2]](diffhunk://#diff-4391ba96fa766542bad5410938cf3c02e6f504d30b83f72172e485a42997e086L5-R19)
  * Modified setup methods in test files to configure Mapster mappings using `TypeAdapterConfig` instead of `MapperConfiguration`. [[1]](diffhunk://#diff-d0c6096aa9f854ec5c8abd833188b0b3fe5f79bc1712a3c6599875af47fb2652L53-R56) [[2]](diffhunk://#diff-8f4d96d28b3e014d2569e6f9c888eb5043eb93ee0bdd2f28610f20ebf604490bL33-R36) [[3]](diffhunk://#diff-3d915f197d82a807e978624c021a5dccce6a1857653d9d5976c1ff681b1671dfL31-R34)

* **Service Configuration:**
  * Replaced AutoMapper service registration with Mapster in `Program.cs` files and added necessary assembly scanning for Mapster configurations. [[1]](diffhunk://#diff-6292ab76b3aa624f92a105102b25100ff73bba2aa9854b30a81987074ee2e9f8L59-R63) [[2]](diffhunk://#diff-dabf0122d6e65ac2e81d345bc13ba68e21d6379ce2c1dcc68980ed05790835acL50-R54)

